### PR TITLE
Even more ways to configure the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # lassie-go
-Lassie provides a client for the [REST API](https://api.lora.telenor.io) for [Telenor LoRa](https://lora.engineering).
+Lassie provides a client for the [REST API](https://api.lora.telenor.io) for
+[Telenor LoRa](https://lora.engineering).
+
+## Configuration
+
+The configuration file is located at `${HOME}/.lassie`. The file is a simple
+list of key/value pairs. Additional values are ignored. Comments should start
+with a `#`:
+
+    #
+    # This is the URL of the Congress REST API. The default value is
+    # https://api.lora.telenor.io and can usually be omitted.
+    address=https://api.lora.telenor.io
+
+    #
+    # This is the API token. Create new token by logging in to the Congress
+    # front-end at https://lora.engineering and create a new token there.
+    token=<your api token goes here>
+
+
+The configuration file settings can be overridden by setting the environment
+variables `LASSIE_ADDRESS` and `LASSIE_TOKEN`. If you only use environment variables
+the configuration file can be ignored.
+
+Use the `NewWithAddr` function to bypass the default configuration file and
+environment variables when you want to create the client programmatically.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Lassie provides a client for the [REST API](https://api.lora.telenor.io) for
 ## Configuration
 
 The configuration file is located at `${HOME}/.lassie`. The file is a simple
-list of key/value pairs. Additional values are ignored. Comments should start
+list of key/value pairs. Additional values are ignored. Comments must start
 with a `#`:
 
     #

--- a/application_test.go
+++ b/application_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestApplication(t *testing.T) {
-	client, err := NewWithAddr(*addr, *token)
+	client, err := New()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client.go
+++ b/client.go
@@ -13,8 +13,6 @@ import (
 	"net/http"
 )
 
-const DefaultAddr = "https://api.lora.telenor.io"
-
 type Client struct {
 	addr   string
 	token  string

--- a/client.go
+++ b/client.go
@@ -21,8 +21,8 @@ type Client struct {
 	client http.Client
 }
 
-func New(token string) (*Client, error) {
-	return NewWithAddr(DefaultAddr, token)
+func New() (*Client, error) {
+	return NewWithAddr(addressTokenFromConfig(ConfigFile))
 }
 
 func NewWithAddr(addr, token string) (*Client, error) {

--- a/client_test.go
+++ b/client_test.go
@@ -1,33 +1,30 @@
 package lassie
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"testing"
 )
 
-var (
-	addr  = flag.String("addr", DefaultAddr, "address")
-	token = flag.String("token", "", "token")
-)
-
 func TestMain(m *testing.M) {
-	flag.Parse()
-	if *token == "" {
-		if _, err := NewWithAddr(*addr, ""); err != nil {
-			fmt.Println("Error creating client:", err)
-			fmt.Println("You might need to specify a token when running the tests against", *addr)
-			fmt.Println("Run `go test -args -token <your-api-token>`.")
-			os.Exit(1)
-		}
+	if _, err := New(); err != nil {
+		fmt.Println("Error creating client:", err)
+		fmt.Println("You might have to configure Lassie via a configuration file or environment variables")
+		os.Exit(1)
 	}
 
 	os.Exit(m.Run())
 }
 
 func TestNew(t *testing.T) {
-	_, err := NewWithAddr(*addr, *token)
+	if _, err := New(); err != nil {
+		t.Fatal("Unable to create the Lassie client. You might have to configure it either through environment variables or through a configuration file")
+	}
+
+}
+
+func TestNewWithAddress(t *testing.T) {
+	_, err := NewWithAddr(addressTokenFromConfig(ConfigFile))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/config.go
+++ b/config.go
@@ -121,3 +121,36 @@ func (u *UserConfig) Token() string {
 	u.readConfig(u.configFile())
 	return u.values[tokenKey]
 }
+
+// Config is a configuration that works both for file configuration and environment variables.
+// The environment variables will override the configuration file.
+type Config struct {
+	fileConfig UserConfig
+	envConfig  EnvironmentConfig
+}
+
+// NewConfig creates a new configuration
+func NewConfig() *Config {
+	return &Config{}
+}
+
+// Address returns configured address. The address will first be read from
+// the file configuration. If neither are set it will return the default
+// address.
+func (c *Config) Address() string {
+	address := c.fileConfig.Address()
+	if c.envConfig.Address() != DefaultAddr {
+		return c.envConfig.Address()
+	}
+	return address
+}
+
+// Token returns the configured token. The environment variable will override the
+// file configuration. I
+func (c *Config) Token() string {
+	token := c.fileConfig.Token()
+	if c.envConfig.Token() != "" {
+		return c.envConfig.Token()
+	}
+	return token
+}

--- a/config.go
+++ b/config.go
@@ -27,6 +27,11 @@ func NewWithConfig(config ClientConfig) (*Client, error) {
 type EnvironmentConfig struct {
 }
 
+// NewEnvironmentConfig creates a new EnvironmentConfig
+func NewEnvironmentConfig() *EnvironmentConfig {
+	return &EnvironmentConfig{}
+}
+
 // Address tries to retrieve the endpoint address (ie https://api.lora.telenor.io)
 // from the environment variable LASSIE_ADDRESS. If is empty it will return the
 // default.
@@ -52,6 +57,11 @@ func (e *EnvironmentConfig) Token() string {
 // Note: This isn't tested on Windows.
 type UserConfig struct {
 	values map[string]string
+}
+
+// NewUserConfig creates a new UserConfig
+func NewUserConfig() *UserConfig {
+	return &UserConfig{}
 }
 
 const (

--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package lassie
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/user"
@@ -76,16 +77,26 @@ func readConfig(filename string) (string, string) {
 	}
 	scanner := bufio.NewScanner(bytes.NewReader(buf))
 	scanner.Split(bufio.ScanLines)
+	lineno := 0
 	for scanner.Scan() {
-		words := strings.Split(scanner.Text(), "=")
-		if len(words) == 1 {
+		lineno++
+		line := strings.ToLower(scanner.Text())
+		if len(line) == 0 || line[0] == '#' {
+			// ignore comments and empty lines
 			continue
 		}
-		switch strings.ToLower(strings.TrimSpace(words[0])) {
+		words := strings.Split(scanner.Text(), "=")
+		if len(words) != 2 {
+			fmt.Printf("Not a key value expression on line %d in %s: %s\n", lineno, filename, scanner.Text())
+			continue
+		}
+		switch words[0] {
 		case addressKey:
 			address = strings.TrimSpace(words[1])
 		case tokenKey:
 			token = strings.TrimSpace(words[1])
+		default:
+			fmt.Printf("Unknown keyword on line %d in %s: %s\n", lineno, filename, scanner.Text())
 		}
 	}
 	return address, token

--- a/config.go
+++ b/config.go
@@ -1,0 +1,105 @@
+package lassie
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+// ClientConfig is a client configuration for Lassie-go
+type ClientConfig interface {
+	// Address returns the address to use
+	Address() string
+	// Token returns the token to use
+	Token() string
+}
+
+// NewWithConfig creates a new client with the provided configuration
+func NewWithConfig(config ClientConfig) (*Client, error) {
+	return NewWithAddr(config.Address(), config.Token())
+}
+
+// EnvironmentConfig gets its configuration from environment variables
+type EnvironmentConfig struct {
+}
+
+// Address tries to retrieve the endpoint address (ie https://api.lora.telenor.io)
+// from the environment variable LASSIE_ADDRESS. If is empty it will return the
+// default.
+func (e *EnvironmentConfig) Address() string {
+	endpoint := os.Getenv("LASSIE_ADDRESS")
+	if endpoint == "" {
+		return DefaultAddr
+	}
+	return endpoint
+}
+
+// Token returns the token from the environment variable LASSIE_TOKEN
+func (e *EnvironmentConfig) Token() string {
+	return os.Getenv("LASSIE_TOKEN")
+}
+
+// UserConfig gets its configuration from a file named ~/.lassie
+//
+// The configuration format is quite simple with "key=value" entries on each
+// line. Only two parameters are supported -- "Address" and "Token". The Address
+// parameter is optional.
+//
+// Note: This isn't tested on Windows.
+type UserConfig struct {
+	values map[string]string
+}
+
+const (
+	configFileName = "~/.lassie"
+	addressKey     = "address"
+	tokenKey       = "token"
+)
+
+// readConfig populates the values map with two elements -- "token" and
+// "address"
+func (u *UserConfig) readConfig(filename string) map[string]string {
+	if u.values == nil {
+		u.values = make(map[string]string)
+		u.values[addressKey] = DefaultAddr
+		u.values[tokenKey] = ""
+
+		buf, err := ioutil.ReadFile(filename)
+		if err != nil {
+			panic(fmt.Sprintf("Unable to read configuration file: %v", err))
+		}
+		scanner := bufio.NewScanner(bytes.NewReader(buf))
+		scanner.Split(bufio.ScanLines)
+		for scanner.Scan() {
+			words := strings.Split(scanner.Text(), "=")
+			if len(words) == 1 {
+				continue
+			}
+			switch strings.ToLower(strings.TrimSpace(words[0])) {
+			case addressKey:
+				u.values[addressKey] = strings.TrimSpace(words[1])
+			case tokenKey:
+				u.values[tokenKey] = strings.TrimSpace(words[1])
+			}
+		}
+	}
+	return u.values
+}
+
+// Address reads the configuration file and checks if the file has the field
+// "address". If the field isn't found it will use the default address. If the
+// configuration file is missing it will panic.
+func (u *UserConfig) Address() string {
+	u.readConfig(configFileName)
+	return u.values[addressKey]
+}
+
+// Token reads the API token from the field "token" in the configuration
+// file. If the configuration file is missing it will panic.
+func (u *UserConfig) Token() string {
+	u.readConfig(configFileName)
+	return u.values[tokenKey]
+}

--- a/config.go
+++ b/config.go
@@ -11,6 +11,10 @@ import (
 )
 
 const (
+	// DefaultAddr is the default address of the Congress API. You normally won't
+	// have to change this.
+	DefaultAddr = "https://api.lora.telenor.io"
+
 	// ConfigFile is the default name for the config file. The configuration
 	// file is a plain text file that contains the default Lassie configuration.
 	// The configuration file is expected to be at the current home directory.

--- a/config_test.go
+++ b/config_test.go
@@ -51,8 +51,8 @@ func TestEnvironmentConfig(t *testing.T) {
 }
 
 func TestClientConfig(t *testing.T) {
-	_, err := NewWithConfig(&EnvironmentConfig{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	// Just exercise the configurations
+	NewEnvironmentConfig()
+	NewUserConfig()
+	NewConfig()
 }

--- a/config_test.go
+++ b/config_test.go
@@ -11,6 +11,7 @@ func TestFileDefaultConfig(t *testing.T) {
 	contents := "address=http://example.com\ntoken=sometoken"
 	tempFile := "lassie.testconfig"
 	ioutil.WriteFile(getFullPath(tempFile), []byte(contents), 0666)
+	defer os.Remove(getFullPath(tempFile))
 
 	// unset the environment first to make sure it won't interfere with the
 	// file. It might contain settings that is in use so set it back to the
@@ -30,14 +31,13 @@ func TestFileDefaultConfig(t *testing.T) {
 		t.Fatalf("Configuration isn't the expected values: %s / %s", address, token)
 	}
 
-	contents = "token=foobar\nsome=thing\nother=thing\n\n\n"
+	contents = "token=foobar\nsome=thing\nother=thing\n\nsome=thing=other\n\n"
 	ioutil.WriteFile(getFullPath(tempFile), []byte(contents), 0666)
 	address, token = addressTokenFromConfig(tempFile)
 	if address != DefaultAddr || token != "foobar" {
 		t.Fatalf("Configuration isn't the expected values: %s / %s", address, token)
 	}
 
-	os.Remove(getFullPath(tempFile))
 }
 
 func TestEnvironmentConfig(t *testing.T) {

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,58 @@
+package lassie
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestUserConfig(t *testing.T) {
+	contents := "address=http://example.com\ntoken=sometoken"
+	tempFile := "tempconfig"
+	ioutil.WriteFile(tempFile, []byte(contents), 0666)
+
+	uc := UserConfig{}
+	uc.values = uc.readConfig(tempFile)
+	if uc.Address() != "http://example.com" || uc.Token() != "sometoken" {
+		t.Fatalf("Configuration isn't the expected values: %v", uc)
+	}
+
+	contents = "token=foobar\nsome=thing\nother=thing\n\n\n"
+	ioutil.WriteFile(tempFile, []byte(contents), 0666)
+	uc = UserConfig{}
+	uc.values = uc.readConfig(tempFile)
+	if uc.Address() != DefaultAddr || uc.Token() != "foobar" {
+		t.Fatalf("Configuration isn't the expected values: %v", uc)
+	}
+
+	os.Remove(tempFile)
+}
+
+func TestEnvironmentConfig(t *testing.T) {
+	os.Setenv("LASSIE_ADDRESS", "")
+	os.Setenv("LASSIE_TOKEN", "")
+
+	env := EnvironmentConfig{}
+	if env.Address() != DefaultAddr {
+		t.Fatal("Expected address to be default")
+	}
+	if env.Token() != "" {
+		t.Fatal("Expected token to be empty")
+	}
+
+	os.Setenv("LASSIE_ADDRESS", "https://example.com")
+	os.Setenv("LASSIE_TOKEN", "foo")
+	if env.Address() != "https://example.com" {
+		t.Fatal("Expected environment variable to override config")
+	}
+	if env.Token() != "foo" {
+		t.Fatal("Expected environment variable to override config")
+	}
+}
+
+func TestClientConfig(t *testing.T) {
+	_, err := NewWithConfig(&EnvironmentConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -13,7 +13,8 @@ func TestFileDefaultConfig(t *testing.T) {
 	ioutil.WriteFile(getFullPath(tempFile), []byte(contents), 0666)
 
 	// unset the environment first to make sure it won't interfere with the
-	// file
+	// file. It might contain settings that is in use so set it back to the
+	// original value afterwards.
 	oldAddr := os.Getenv(AddressEnvironmentVariable)
 	oldToken := os.Getenv(TokenEnvironmentVariable)
 	defer func() {

--- a/device_test.go
+++ b/device_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestDevice(t *testing.T) {
-	client, err := NewWithAddr(*addr, *token)
+	client, err := New()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestGateway(t *testing.T) {
-	client, err := NewWithAddr(*addr, *token)
+	client, err := New()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Add two convenience classes for configuration -- one that uses the environment and one that uses a configuration file in the user's home directory.

The latter is mainly for development.