### PR TITLE
Minor fixes; Address method on Client

### DIFF
--- a/application.go
+++ b/application.go
@@ -93,8 +93,6 @@ func (c *Client) ApplicationStream(appeui string, handler func(DeviceData)) erro
 			// Ignore it
 		}
 	}
-
-	return nil
 }
 
 // DeviceData represents data received from a device.

--- a/client.go
+++ b/client.go
@@ -1,5 +1,5 @@
 /*
-Lassie provides a client for the REST API for Telenor LoRa.
+Package lassie provides a client for the REST API for Telenor LoRa.
 
 All Create* and Update* methods return the created and updated entity, respectively, which may include setting fields that were not set.
 */
@@ -13,22 +13,32 @@ import (
 	"net/http"
 )
 
+// Client is a client for the Congress service.
 type Client struct {
 	addr   string
 	token  string
 	client http.Client
 }
 
+// New creates a new client with the default configuration. The default
+// configuration can be specified in a configuration file or through
+// environment variables.
 func New() (*Client, error) {
 	return NewWithAddr(addressTokenFromConfig(ConfigFile))
 }
 
+// NewWithAddr creates a new client with the specified address and token.
 func NewWithAddr(addr, token string) (*Client, error) {
 	c := &Client{
 		addr:  addr,
 		token: token,
 	}
 	return c, c.ping()
+}
+
+// Address returns the client's address.
+func (c *Client) Address() string {
+	return c.addr
 }
 
 func (c *Client) ping() error {
@@ -80,6 +90,7 @@ func (c *Client) request(method, path string, input, output interface{}) error {
 	return nil
 }
 
+// ClientError is the errors returned by the Client.
 type ClientError struct {
 	HTTPStatusCode int
 	Message        string

--- a/client.go
+++ b/client.go
@@ -13,7 +13,7 @@ import (
 	"net/http"
 )
 
-// Client is a client for the Congress service.
+// Client is a client for the Telenor LoRa-as-a-Service API.
 type Client struct {
 	addr   string
 	token  string


### PR DESCRIPTION
Added comments on exported members and removed unreachable code in ApplicationStream method; gave linter warnings.

Added Address() method to get the current address in use. Nice when printing diagnostic messages in clients. There's no Token() method for obvious reasons :) 